### PR TITLE
feat: aviso de contests futuros

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Falforces é um bot que tem como objetivo promover a Programação Competitiva d
 - 🔍 Analisar seu perfil do Codeforces de maneira mais detalhada
 - 🕵️ Stalkear seu amigo e ver quais exercícios ele fez sem você
 - ⏰ Receber notificações de contests
+- 🫶 Match algorítimico, verificar a similariedade entre você e um amigo
 - 🎖️ Crie insignias personalizadas para participantes de competições oficiais
 - ✨ E muito mais!
 

--- a/src/bot.js
+++ b/src/bot.js
@@ -81,7 +81,7 @@ class Bot {
 								const embed = this.createEmbed("#C12127")
 									.setTitle(`${contest.name}`)
 									.setDescription(
-										`O contest vai começar <t:${contest.startTimeSeconds}:R>!\n\n**Início:** <t:${
+										`O contest vai começar <t:${contest.startTimeSeconds}:R>! :balloon:\n\n**Início:** <t:${
 											contest.startTimeSeconds
 										}:F>\n**Duração:** ${contest.durationSeconds / 60 / 60} horas\n**Tipo:** ${contest.type}`
 									)

--- a/src/bot.js
+++ b/src/bot.js
@@ -61,7 +61,7 @@ class Bot {
 			const notifyContests = async () => {
 				for (const contest of this.upcomingContests) {
 					const timeRemaining = contest.startTimeSeconds * 1000 - Date.now()
-					if (timeRemaining <= 1000 * 60 * 60 * 48) {
+					if (timeRemaining <= 1000 * 60 * 60 * 24) {
 						if (!contest.reminded1day) {
 							contest.reminded1day = true
 						} else if (timeRemaining <= 1000 * 60 * 60 * 1 && !contest.reminded1hour) {

--- a/src/commands/contest.js
+++ b/src/commands/contest.js
@@ -1,0 +1,41 @@
+const { SlashCommandBuilder } = require("discord.js")
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName("contest")
+		.setDescription("Use esse comando para ser avisado sobre contests futuros do Codeforces")
+		.addChannelOption((channel) =>
+			channel.setName("canal").setDescription("Canal onde você deseja receber as notificações").setRequired(true)
+		),
+	execute: async ({ interaction, instance }) => {
+		try {
+			await interaction.deferReply()
+
+			const channel = interaction.options.getChannel("canal")
+
+			await instance.guildSchema.findByIdAndUpdate(
+				interaction.guild.id,
+				{
+					notificationChannel: channel.id,
+				},
+				{ upsert: true }
+			)
+
+			const embed = await instance
+				.createEmbed("#551976")
+				.setTitle(`:mega: Notificações Ativadas!`)
+				.setDescription(
+					`Você receberá notificações um dia e uma hora antes de cada contest do Codeforces no canal ${channel}`
+				)
+				.addFields({ name: "\u200B", value: "**Para desativar as notificações, use o comando `/parar`**" })
+			await interaction.editReply({
+				embeds: [embed],
+			})
+		} catch (error) {
+			console.error(`contest: ${error}`)
+			interaction.editReply({
+				content: instance.getMessage(interaction, "EXCEPTION"),
+			})
+		}
+	},
+}

--- a/src/commands/contest.js
+++ b/src/commands/contest.js
@@ -23,7 +23,7 @@ module.exports = {
 
 			const embed = await instance
 				.createEmbed("#551976")
-				.setTitle(`:mega: Notificações Ativadas!`)
+				.setTitle(`:bell: Notificações Ativadas!`)
 				.setDescription(
 					`Você receberá notificações um dia e uma hora antes de cada contest do Codeforces no canal ${channel}`
 				)

--- a/src/commands/contest.js
+++ b/src/commands/contest.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require("discord.js")
+const { SlashCommandBuilder, PermissionFlagsBits } = require("discord.js")
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,7 +6,8 @@ module.exports = {
 		.setDescription("Use esse comando para ser avisado sobre contests futuros do Codeforces")
 		.addChannelOption((channel) =>
 			channel.setName("canal").setDescription("Canal onde você deseja receber as notificações").setRequired(true)
-		),
+		)
+		.setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
 	execute: async ({ interaction, instance }) => {
 		try {
 			await interaction.deferReply()

--- a/src/commands/parar.js
+++ b/src/commands/parar.js
@@ -1,9 +1,10 @@
-const { SlashCommandBuilder } = require("discord.js")
+const { SlashCommandBuilder, PermissionFlagsBits } = require("discord.js")
 
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName("parar")
-		.setDescription("Use esse comando para parar de receber notificações sobre contests"),
+		.setDescription("Use esse comando para parar de receber notificações sobre contests")
+		.setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
 	execute: async ({ interaction, instance }) => {
 		try {
 			await interaction.deferReply()

--- a/src/commands/parar.js
+++ b/src/commands/parar.js
@@ -18,7 +18,7 @@ module.exports = {
 
 			const embed = await instance
 				.createEmbed("#551976")
-				.setTitle(`:mega: Notificações Desativadas!`)
+				.setTitle(`:no_bell: Notificações Desativadas!`)
 				.setDescription(`Você não receberá mais notificações sobre contests do Codeforces.`)
 			await interaction.editReply({
 				embeds: [embed],

--- a/src/commands/parar.js
+++ b/src/commands/parar.js
@@ -1,0 +1,33 @@
+const { SlashCommandBuilder } = require("discord.js")
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName("parar")
+		.setDescription("Use esse comando para parar de receber notificações sobre contests"),
+	execute: async ({ interaction, instance }) => {
+		try {
+			await interaction.deferReply()
+
+			await instance.guildSchema.findByIdAndUpdate(
+				interaction.guild.id,
+				{
+					notificationChannel: null,
+				},
+				{ upsert: true }
+			)
+
+			const embed = await instance
+				.createEmbed("#551976")
+				.setTitle(`:mega: Notificações Desativadas!`)
+				.setDescription(`Você não receberá mais notificações sobre contests do Codeforces.`)
+			await interaction.editReply({
+				embeds: [embed],
+			})
+		} catch (error) {
+			console.error(`parar: ${error}`)
+			interaction.editReply({
+				content: instance.getMessage(interaction, "EXCEPTION"),
+			})
+		}
+	},
+}

--- a/src/schemas/guild.js
+++ b/src/schemas/guild.js
@@ -1,0 +1,14 @@
+const mongoose = require("mongoose")
+
+const guildSchema = mongoose.Schema(
+	{
+		_id: { type: String, required: true },
+		notificationChannel: { type: String, default: null },
+	},
+	{
+		versionKey: false,
+		timestamps: true,
+	}
+)
+
+module.exports = mongoose.model("guilds", guildSchema)


### PR DESCRIPTION
## What does this PR do?
Cria nova schema, dois comandos e duas funções no arquivo principal do bot que permitem que os servidores sejam avisados de contests futuros do codeforces, os avisos são feitos 1 dia e 1 hora antes de cada um

## Summary of changes
- Novos comandos: contest e parar
- Nova schema: guilds
- Duas funções novas no bot.js: fetchContests e notifyContests

## Media
<img width="509" height="267" alt="image" src="https://github.com/user-attachments/assets/a1584f66-1ed2-4a56-bfea-ed85828a18c4" />
<img width="745" height="496" alt="image" src="https://github.com/user-attachments/assets/25c65ff9-faf4-49f0-b895-eabbc541f726" />
