### PR TITLE
feat: contests atcoder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "GNU 3.0",
 			"dependencies": {
+				"@qatadaazzeh/atcoder-api": "^1.0.1",
 				"discord.js": "^14.18.0",
 				"dotenv": "^16.0.1",
 				"mongoose": "^6.8.0"
@@ -697,15 +698,15 @@
 			}
 		},
 		"node_modules/@discordjs/builders": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.10.1.tgz",
-			"integrity": "sha512-OWo1fY4ztL1/M/DUyRPShB4d/EzVfuUvPTRRHRIt/YxBrUYSz0a+JicD5F5zHFoNs2oTuWavxCOVFV1UljHTng==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.0.tgz",
+			"integrity": "sha512-COK0uU6ZaJI+LA67H/rp8IbEkYwlZf3mAoBI5wtPh5G5cbEQGNhVpzINg2f/6+q/YipnNIKy6fJDg6kMUKUw4Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@discordjs/formatters": "^0.6.0",
+				"@discordjs/formatters": "^0.6.1",
 				"@discordjs/util": "^1.1.1",
 				"@sapphire/shapeshift": "^4.0.0",
-				"discord-api-types": "^0.37.119",
+				"discord-api-types": "^0.38.31",
 				"fast-deep-equal": "^3.1.3",
 				"ts-mixer": "^6.0.4",
 				"tslib": "^2.6.3"
@@ -727,12 +728,12 @@
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0.tgz",
-			"integrity": "sha512-YIruKw4UILt/ivO4uISmrGq2GdMY6EkoTtD0oS0GvkJFRZbTSdPhzYiUILbJ/QslsvC9H9nTgGgnarnIl4jMfw==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.1.tgz",
+			"integrity": "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"discord-api-types": "^0.37.114"
+				"discord-api-types": "^0.38.1"
 			},
 			"engines": {
 				"node": ">=16.11.0"
@@ -742,9 +743,9 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.3.tgz",
-			"integrity": "sha512-+SO4RKvWsM+y8uFHgYQrcTl/3+cY02uQOH7/7bKbVZsTfrfpoE62o5p+mmV+s7FVhTX82/kQUGGbu4YlV60RtA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+			"integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.1",
@@ -752,10 +753,10 @@
 				"@sapphire/async-queue": "^1.5.3",
 				"@sapphire/snowflake": "^3.5.3",
 				"@vladfrangu/async_event_emitter": "^2.4.6",
-				"discord-api-types": "^0.37.119",
+				"discord-api-types": "^0.38.16",
 				"magic-bytes.js": "^1.10.0",
 				"tslib": "^2.6.3",
-				"undici": "6.21.1"
+				"undici": "6.21.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -789,18 +790,18 @@
 			}
 		},
 		"node_modules/@discordjs/ws": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.1.tgz",
-			"integrity": "sha512-PBvenhZG56a6tMWF/f4P6f4GxZKJTBG95n7aiGSPTnodmz4N5g60t79rSIAq7ywMbv8A4jFtexMruH+oe51aQQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+			"integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
-				"@discordjs/rest": "^2.4.3",
+				"@discordjs/rest": "^2.5.1",
 				"@discordjs/util": "^1.1.0",
 				"@sapphire/async-queue": "^1.5.2",
 				"@types/ws": "^8.5.10",
 				"@vladfrangu/async_event_emitter": "^2.2.4",
-				"discord-api-types": "^0.37.119",
+				"discord-api-types": "^0.38.1",
 				"tslib": "^2.6.2",
 				"ws": "^8.17.0"
 			},
@@ -831,6 +832,19 @@
 			"optional": true,
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
+			}
+		},
+		"node_modules/@qatadaazzeh/atcoder-api": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@qatadaazzeh/atcoder-api/-/atcoder-api-1.0.1.tgz",
+			"integrity": "sha512-KmobXV3ONrvi5Xwf13aaNAHlQbrnclScd7v9Gh3WdCpRGgz8Fh03LZi2UrC+9c7Eum9DeYTBHUS6SXzPoPU0Ng==",
+			"license": "MIT",
+			"dependencies": {
+				"cheerio": "^1.0.0",
+				"node-fetch": "^2.6.12"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@sapphire/async-queue": {
@@ -1492,18 +1506,18 @@
 			}
 		},
 		"node_modules/@types/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
 		},
 		"node_modules/@vladfrangu/async_event_emitter": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
-			"integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+			"integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=v14.0.0",
@@ -1529,6 +1543,12 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"license": "ISC"
 		},
 		"node_modules/bowser": {
 			"version": "2.11.0",
@@ -1573,6 +1593,85 @@
 				"ieee754": "^1.1.13"
 			}
 		},
+		"node_modules/cheerio": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+			"integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+			"license": "MIT",
+			"dependencies": {
+				"cheerio-select": "^2.1.0",
+				"dom-serializer": "^2.0.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.2.2",
+				"encoding-sniffer": "^0.2.1",
+				"htmlparser2": "^10.0.0",
+				"parse5": "^7.3.0",
+				"parse5-htmlparser2-tree-adapter": "^7.1.0",
+				"parse5-parser-stream": "^7.1.2",
+				"undici": "^7.12.0",
+				"whatwg-mimetype": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=20.18.1"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+			}
+		},
+		"node_modules/cheerio-select": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-select": "^5.1.0",
+				"css-what": "^6.1.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cheerio/node_modules/undici": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+			"integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/css-select": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1595,29 +1694,33 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.37.119",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.119.tgz",
-			"integrity": "sha512-WasbGFXEB+VQWXlo6IpW3oUv73Yuau1Ig4AZF/m13tXcTKnMpc/mHjpztIlz4+BM9FG9BHQkEXiPto3bKduQUg==",
-			"license": "MIT"
+			"version": "0.38.31",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.31.tgz",
+			"integrity": "sha512-kC94ANsk8ackj8ENTuO8joTNEL0KtymVhHy9dyEC/s4QAZ7GCx40dYEzQaadyo8w+oP0X8QydE/nzAWRylTGtQ==",
+			"license": "MIT",
+			"workspaces": [
+				"scripts/actions/documentation"
+			]
 		},
 		"node_modules/discord.js": {
-			"version": "14.18.0",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.18.0.tgz",
-			"integrity": "sha512-SvU5kVUvwunQhN2/+0t55QW/1EHfB1lp0TtLZUSXVHDmyHTrdOj5LRKdR0zLcybaA15F+NtdWuWmGOX9lE+CAw==",
+			"version": "14.24.2",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.24.2.tgz",
+			"integrity": "sha512-VMEDbmguRdX/EeMaTsf9Mb0IQA90WdYF2cn4QDfslQFXgQ6LFtmlPn0FSotnS0kcFbFp+JBSIxtnF+bnAHG/hQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@discordjs/builders": "^1.10.1",
+				"@discordjs/builders": "^1.13.0",
 				"@discordjs/collection": "1.5.3",
-				"@discordjs/formatters": "^0.6.0",
-				"@discordjs/rest": "^2.4.3",
+				"@discordjs/formatters": "^0.6.1",
+				"@discordjs/rest": "^2.6.0",
 				"@discordjs/util": "^1.1.1",
-				"@discordjs/ws": "^1.2.1",
+				"@discordjs/ws": "^1.2.3",
 				"@sapphire/snowflake": "3.5.3",
-				"discord-api-types": "^0.37.119",
+				"discord-api-types": "^0.38.31",
 				"fast-deep-equal": "3.1.3",
 				"lodash.snakecase": "4.1.1",
+				"magic-bytes.js": "^1.10.0",
 				"tslib": "^2.6.3",
-				"undici": "6.21.1"
+				"undici": "6.21.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -1626,12 +1729,92 @@
 				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
 		"node_modules/dotenv": {
 			"version": "16.0.1",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
 			"integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/encoding-sniffer": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+			"integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "^0.6.3",
+				"whatwg-encoding": "^3.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -1661,6 +1844,49 @@
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/htmlparser2": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+			"integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.2.1",
+				"entities": "^6.0.0"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ieee754": {
@@ -1722,9 +1948,9 @@
 			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
 		},
 		"node_modules/magic-bytes.js": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
-			"integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
+			"integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
 			"license": "MIT"
 		},
 		"node_modules/memory-pager": {
@@ -1808,6 +2034,109 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/node-fetch/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT"
+		},
+		"node_modules/node-fetch/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/node-fetch/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+			"integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+			"license": "MIT",
+			"dependencies": {
+				"domhandler": "^5.0.3",
+				"parse5": "^7.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5-parser-stream": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+			"integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+			"license": "MIT",
+			"dependencies": {
+				"parse5": "^7.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1816,6 +2145,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
 		},
 		"node_modules/sift": {
 			"version": "16.0.1",
@@ -1900,9 +2235,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/undici": {
-			"version": "6.21.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-			"integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+			"version": "6.21.3",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+			"integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
@@ -1931,6 +2266,27 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/whatwg-url": {
 			"version": "11.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
@@ -1945,9 +2301,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.18.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-			"integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+			"version": "8.18.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"author": "Falcão",
 	"license": "GNU 3.0",
 	"dependencies": {
+		"@qatadaazzeh/atcoder-api": "^1.0.1",
 		"discord.js": "^14.18.0",
 		"dotenv": "^16.0.1",
 		"mongoose": "^6.8.0"

--- a/src/bot.js
+++ b/src/bot.js
@@ -60,7 +60,10 @@ class Bot {
 							name: c.contestName,
 							type: c.contestType,
 							startTimeSeconds: Math.floor(new Date(c.contestTime).getTime() / 1000),
-							durationSeconds: c.contestDuration.split(":").reduce((acc, time) => 60 * 60 * acc + +time, 0),
+							durationSeconds: c.contestDuration.split(":").reduce((acc, time, index) => {
+								if (index === 0) return Number(time) * 3600
+								return acc + Number(time) * 60
+							}, 0),
 							url: c.contestUrl,
 							reminded1day: false,
 							reminded1hour: false,

--- a/src/commands/contest.js
+++ b/src/commands/contest.js
@@ -3,10 +3,10 @@ const { SlashCommandBuilder, PermissionFlagsBits } = require("discord.js")
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName("contest")
-		.setDescription("Use esse comando para ser avisado sobre contests futuros do Codeforces")
+		.setDescription("Use esse comando para ser avisado sobre contests futuros do Codeforces e AtCoder")
 		.setDescriptionLocalizations({
-			"en-US": "Use this command to be notified about upcoming Codeforces contests",
-			"es-ES": "Usa este comando para recibir notificaciones sobre futuros concursos de Codeforces",
+			"en-US": "Use this command to be notified about upcoming Codeforces and AtCoder contests",
+			"es-ES": "Usa este comando para recibir notificaciones sobre futuros concursos de Codeforces y AtCoder",
 		})
 		.addChannelOption((channel) =>
 			channel

--- a/src/commands/futuros.js
+++ b/src/commands/futuros.js
@@ -1,0 +1,56 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require("discord.js")
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName("futuros")
+		.setNameLocalizations({
+			"en-US": "upcoming",
+		})
+		.setDescription("Use esse comando para ver os próximos contests do Codeforces e AtCoder")
+		.setDescriptionLocalizations({
+			"en-US": "Use this command to see upcoming Codeforces and AtCoder contests",
+			"es-ES": "Utiliza este comando para ver los próximos concursos de Codeforces y AtCoder",
+		}),
+	execute: async ({ interaction, bot }) => {
+		try {
+			await interaction.deferReply()
+
+			const upcomingContests = []
+			// upcomingContests is a map, so we need to convert it to an array and sort it by startTime
+			const sortedContests = Array.from(bot.upcomingContests.values()).sort(
+				(a, b) => a.startTimeSeconds - b.startTimeSeconds
+			)
+			for (const contest of sortedContests) {
+				if (upcomingContests.length >= 3) break
+				upcomingContests.push(contest)
+			}
+
+			const embed = await bot.createEmbed("#551976").setTitle(bot.i18n.get(interaction, "commands.futuros.embed.title"))
+
+			for (const contest of upcomingContests) {
+				embed.addFields({
+					name: contest.name,
+					value: bot.i18n.get(interaction, "commands.futuros.embed.field_contest", {
+						LINK: contest.url,
+						INICIO: `<t:${contest.startTimeSeconds}:F>`,
+						DURACAO: (contest.durationSeconds / 3600).toFixed(2),
+						TIPO: contest.type,
+					}),
+				})
+			}
+
+			if (upcomingContests.length === 0) {
+				embed.setDescription(bot.i18n.get(interaction, "commands.futuros.embed.field_no_contests"))
+			}
+
+			await interaction.editReply({
+				embeds: [embed],
+			})
+		} catch (error) {
+			console.error(`futuros: ${error}`)
+			interaction.editReply({
+				content: bot.i18n.get(interaction, "errors.exception"),
+			})
+		}
+	},
+}

--- a/src/i18n/en-us.json
+++ b/src/i18n/en-us.json
@@ -53,6 +53,13 @@
     "stalk": {
       "response": "Last problems that {AMIGO} did... :telescope:",
       "response_none": "{AMIGO} didn't do any problems yet! :worried:"
+    },
+    "futuros": {
+      "embed": {
+        "title": ":calendar: Upcoming Contests from Codeforces and AtCoder",
+        "field_no_contests": "No upcoming contests found! :thinking:",
+        "field_contest": "**Start:** {INICIO}  :balloon:\n**Link:** {LINK}\n**Duration:** {DURACAO} hours\n**Type:** {TIPO}"
+      }
     }
   },
   "events": {

--- a/src/i18n/en-us.json
+++ b/src/i18n/en-us.json
@@ -6,7 +6,7 @@
     "contest": {
       "embed": {
         "title": ":bell: Notifications Enabled!",
-        "description": "You will receive notifications one day and one hour before each Codeforces contest in the channel {CANAL}",
+        "description": "You will receive notifications one day and one hour before each contest in the channel {CANAL}",
         "field_value": "**To disable notifications, use the `/stop` command**"
       }
     },
@@ -25,7 +25,7 @@
     "parar": {
       "embed": {
         "title": ":no_bell: Notifications Disabled!",
-        "description": "You will no longer receive notifications about Codeforces contests."
+        "description": "You will no longer receive notifications about contests."
       }
     },
     "ping": {

--- a/src/i18n/es-es.json
+++ b/src/i18n/es-es.json
@@ -53,6 +53,13 @@
     "stalk": {
       "response": "Últimos problemas que {AMIGO} hizo... :telescope:",
       "response_none": "{AMIGO} no hizo ningún problema aún! :worried:"
+    },
+    "futuros": {
+      "embed": {
+        "title": ":calendar: Próximos Contests do Codeforces e AtCoder",
+        "field_no_contests": "¡Ningún contest futuro encontrado! :thinking:",
+        "field_contest": "**Inicio:** {INICIO}  :balloon:\n**Link:** {LINK}\n**Duración:** {DURACAO} horas\n**Tipo:** {TIPO}"
+      }
     }
   },
   "events": {

--- a/src/i18n/es-es.json
+++ b/src/i18n/es-es.json
@@ -6,7 +6,7 @@
     "contest": {
       "embed": {
         "title": ":bell: ¡Notificaciones Activadas!",
-        "description": "Recibirás notificaciones un día y una hora antes de cada contest de Codeforces en el canal {CANAL}",
+        "description": "Recibirás notificaciones un día y una hora antes de cada contest en el canal {CANAL}",
         "field_value": "**Para desactivar las notificaciones, usa el comando `/parar`**"
       }
     },
@@ -25,7 +25,7 @@
     "parar": {
       "embed": {
         "title": ":no_bell: ¡Notificaciones Desactivadas!",
-        "description": "No recibirás más notificaciones sobre contests de Codeforces."
+        "description": "No recibirás más notificaciones sobre contests."
       }
     },
     "ping": {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -6,7 +6,7 @@
     "contest": {
       "embed": {
         "title": ":bell: Notificações Ativadas!",
-        "description": "Você receberá notificações um dia e uma hora antes de cada contest do Codeforces no canal {CANAL}",
+        "description": "Você receberá notificações um dia e uma hora antes de cada contest no canal {CANAL}",
         "field_value": "**Para desativar as notificações, use o comando `/parar`**"
       }
     },
@@ -25,7 +25,7 @@
     "parar": {
       "embed": {
         "title": ":no_bell: Notificações Desativadas!",
-        "description": "Você não receberá mais notificações sobre contests do Codeforces."
+        "description": "Você não receberá mais notificações sobre contests."
       }
     },
     "ping": {

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -53,6 +53,13 @@
     "stalk": {
       "response": "Últimos problemas que {AMIGO} fez... :telescope:",
       "response_none": "{AMIGO} não fez nenhum problema ainda! :worried:"
+    },
+    "futuros": {
+      "embed": {
+        "title": ":calendar: Próximos Contests do Codeforces e AtCoder",
+        "field_no_contests": "Nenhum contest futuro encontrado! :thinking:",
+        "field_contest": "**Início:** {INICIO}  :balloon:\n**Link:** {LINK}\n**Duração:** {DURACAO} horas\n**Tipo:** {TIPO}"
+      }
     }
   },
   "events": {


### PR DESCRIPTION
- **feat: puxa contests do at coder**
- **fix não é só mais do codeforces**
- **fix: calculo de tempo do atcoder**
- **feat: comando futuros contests**

## O que este PR faz?
Esse pr adiciona suporte para contest do atcoder em notificações e um comando que lista os próximos contests de ambos codeforces e atcoder

## Resumo das alterações
- Nova dependência: atcoder-api
- Novo comando: futuros
- Contests do atcoder vão ser notificados
- Novas mensagens para o comando
- Alteração de mensagens que falavam de contest só do codeforces

## Mídia
<img width="770" height="578" alt="image" src="https://github.com/user-attachments/assets/cc10a3f3-f452-49a6-aba9-3914d5a2c914" />
<img width="711" height="259" alt="image" src="https://github.com/user-attachments/assets/9bf119ca-6c3c-4bb1-acee-0745151bd68b" />
