### PR TITLE
feat: melhor texto de duração dos contests

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -3,6 +3,7 @@ const { loadEvents } = require("./handlers/events.js")
 const { loadCommands } = require("./handlers/commands.js")
 const { fetchUpcomingContests } = require("@qatadaazzeh/atcoder-api")
 const I18n = require("./handlers/i18n.js")
+const { msToTime } = require("./utils/functions.js")
 const TEN_MINUTES = 10 * 60 * 1000
 const ONE_HOUR = 60 * 60 * 1000
 const ONE_DAY = 24 * 60 * 60 * 1000
@@ -251,7 +252,7 @@ class Bot {
 						this.i18n.get(null, "events.contest_notification", {
 							TEMPO: `<t:${contest.data.startTimeSeconds}:R>`,
 							INICIO: `<t:${contest.data.startTimeSeconds}:F>`,
-							DURACAO: (contest.data.durationSeconds / 3600).toFixed(1),
+							DURACAO: msToTime(contest.data.durationSeconds * 1000),
 							TIPO: contest.type,
 						})
 					)

--- a/src/commands/futuros.js
+++ b/src/commands/futuros.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder } = require("discord.js")
+const { msToTime } = require("../utils/functions.js")
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -34,7 +35,7 @@ module.exports = {
 					value: bot.i18n.get(interaction, "commands.futuros.embed.field_contest", {
 						LINK: contest.data.url,
 						INICIO: `<t:${contest.data.startTimeSeconds}:F>`,
-						DURACAO: (contest.data.durationSeconds / 3600).toFixed(2),
+						DURACAO: msToTime(contest.data.durationSeconds * 1000),
 						TIPO: contest.type,
 					}),
 				})

--- a/src/i18n/en-us.json
+++ b/src/i18n/en-us.json
@@ -58,12 +58,12 @@
       "embed": {
         "title": ":calendar: Upcoming Contests from Codeforces and AtCoder",
         "field_no_contests": "No upcoming contests found! :thinking:",
-        "field_contest": "**Start:** {INICIO}  :balloon:\n**Link:** {LINK}\n**Duration:** {DURACAO} hours\n**Type:** {TIPO}"
+        "field_contest": "**Start:** {INICIO}  :balloon:\n**Link:** {LINK}\n**Duration:** {DURACAO}\n**Type:** {TIPO}"
       }
     }
   },
   "events": {
-    "contest_notification": "The contest will start {TEMPO}! :balloon:\n\n**Start:** {INICIO}\n**Duration:** {DURACAO }hours\n**Type:** {TIPO}"
+    "contest_notification": "The contest will start {TEMPO}! :balloon:\n\n**Start:** {INICIO}\n**Duration:** {DURACAO}\n**Type:** {TIPO}"
   },
   "words": {
     "estatisticas": "Statistics",

--- a/src/i18n/es-es.json
+++ b/src/i18n/es-es.json
@@ -58,12 +58,12 @@
       "embed": {
         "title": ":calendar: Próximos Contests do Codeforces e AtCoder",
         "field_no_contests": "¡Ningún contest futuro encontrado! :thinking:",
-        "field_contest": "**Inicio:** {INICIO}  :balloon:\n**Link:** {LINK}\n**Duración:** {DURACAO} horas\n**Tipo:** {TIPO}"
+        "field_contest": "**Inicio:** {INICIO}  :balloon:\n**Link:** {LINK}\n**Duración:** {DURACAO}\n**Tipo:** {TIPO}"
       }
     }
   },
   "events": {
-    "contest_notification": "¡El contest comenzará {TEMPO}! :balloon:\n\n**Inicio:** {INICIO}\n**Duración:** {DURACAO }horas\n**Tipo:** {TIPO}"
+    "contest_notification": "¡El contest comenzará {TEMPO}! :balloon:\n\n**Inicio:** {INICIO}\n**Duración:** {DURACAO}\n**Tipo:** {TIPO}"
   },
   "words": {
     "estatisticas": "Estadísticas",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -58,12 +58,12 @@
       "embed": {
         "title": ":calendar: Próximos Contests do Codeforces e AtCoder",
         "field_no_contests": "Nenhum contest futuro encontrado! :thinking:",
-        "field_contest": "**Início:** {INICIO}  :balloon:\n**Link:** {LINK}\n**Duração:** {DURACAO} horas\n**Tipo:** {TIPO}"
+        "field_contest": "**Início:** {INICIO}  :balloon:\n**Link:** {LINK}\n**Duração:** {DURACAO}\n**Tipo:** {TIPO}"
       }
     }
   },
   "events": {
-    "contest_notification": "O contest vai começar {TEMPO}! :balloon:\n\n**Início:** {INICIO}\n**Duração:** {DURACAO} horas\n**Tipo:** {TIPO}"
+    "contest_notification": "O contest vai começar {TEMPO}! :balloon:\n\n**Início:** {INICIO}\n**Duração:** {DURACAO}\n**Tipo:** {TIPO}"
   },
   "words": {
     "estatisticas": "Estatísticas",

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -35,12 +35,6 @@ function msToTime(ms) {
 	let time = ""
 
 	let n = 0
-	if (ms >= 2592000000) {
-		n = Math.floor(ms / 2592000000)
-		time += `${n}m `
-		ms -= n * 2592000000
-	}
-
 	if (ms >= 86400000) {
 		n = Math.floor(ms / 86400000)
 		time += `${n}d `

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -27,7 +27,7 @@ async function loadFiles(dirName) {
 
 /**
  * @param {integer} ms
- * @description Converts milliseconds to a string with the format "1m 1d 1h 1m 1s"
+ * @description Converts milliseconds to a string with the format "1d 1h 1m"
  * @example msToTime(1000) // 1s
  * @returns {string}
  */


### PR DESCRIPTION
- **feat: melhora texto de duracao dos contests**
- **fix: remove o mes do msToTime**

## O que este PR faz?
Melhora o texto de duração dos contests, antes, quando um contest tinha, por exemplo, 1 hora e 40 minutos, aparecia 1.7 horas, agora aparece 1h 40m

## Resumo das alterações
- Retirada da palavra "horas" nos arquivos de i18n para flexibilizar o texto
- Uso da função msToTime para criação do texto de duração
- Remoção dos "meses" na função acima para não confundir com os minutos, é melhor que apareça 40 dias se for o caso